### PR TITLE
add org options into config to fix influx 2.x organization settings.

### DIFF
--- a/drivers/influx/src/main/kotlin/dev/cubxity/plugins/metrics/influx/InfluxMetricsDriver.kt
+++ b/drivers/influx/src/main/kotlin/dev/cubxity/plugins/metrics/influx/InfluxMetricsDriver.kt
@@ -43,7 +43,7 @@ class InfluxMetricsDriver(private val api: UnifiedMetrics, private val config: C
                 config[InfluxSpec.password].toCharArray()
             )
             .bucket(config[InfluxSpec.bucket])
-            .org("-")
+            .org(config[InfluxSpec.organization])
             .build()
 
         influxDBClient = InfluxDBClientFactory.create(options)

--- a/drivers/influx/src/main/kotlin/dev/cubxity/plugins/metrics/influx/config/InfluxSpec.kt
+++ b/drivers/influx/src/main/kotlin/dev/cubxity/plugins/metrics/influx/config/InfluxSpec.kt
@@ -22,6 +22,7 @@ import com.uchuhimo.konf.ConfigSpec
 
 object InfluxSpec : ConfigSpec("influx") {
     val url by optional("http://influxdb:8086", "url")
+    val organization by optional("organization", "org")
     val bucket by optional("unifiedmetrics", "bucket")
     val username by optional("influx", "username")
     val password by optional("influx", "password")

--- a/drivers/influx/src/main/kotlin/dev/cubxity/plugins/metrics/influx/config/InfluxSpec.kt
+++ b/drivers/influx/src/main/kotlin/dev/cubxity/plugins/metrics/influx/config/InfluxSpec.kt
@@ -22,7 +22,7 @@ import com.uchuhimo.konf.ConfigSpec
 
 object InfluxSpec : ConfigSpec("influx") {
     val url by optional("http://influxdb:8086", "url")
-    val organization by optional("organization", "-")
+    val organization by optional("-", "organization")
     val bucket by optional("unifiedmetrics", "bucket")
     val username by optional("influx", "username")
     val password by optional("influx", "password")

--- a/drivers/influx/src/main/kotlin/dev/cubxity/plugins/metrics/influx/config/InfluxSpec.kt
+++ b/drivers/influx/src/main/kotlin/dev/cubxity/plugins/metrics/influx/config/InfluxSpec.kt
@@ -22,7 +22,7 @@ import com.uchuhimo.konf.ConfigSpec
 
 object InfluxSpec : ConfigSpec("influx") {
     val url by optional("http://influxdb:8086", "url")
-    val organization by optional("organization", "org")
+    val organization by optional("organization", "-")
     val bucket by optional("unifiedmetrics", "bucket")
     val username by optional("influx", "username")
     val password by optional("influx", "password")


### PR DESCRIPTION
fixes this(i hope)
```
[15:20:04 ERROR]: [com.influxdb.client.write.events.WriteErrorEvent] The error occurred during writing of data
com.influxdb.exceptions.NotFoundException: organization name "-" not found
```

part of #19 
influxdb 2.x uses organizations too, so the config should also contain organization options.