### PR TITLE
feat: add fabric support

### DIFF
--- a/api/src/main/kotlin/dev/cubxity/plugins/metrics/api/platform/PlatformType.kt
+++ b/api/src/main/kotlin/dev/cubxity/plugins/metrics/api/platform/PlatformType.kt
@@ -21,6 +21,7 @@ sealed class PlatformType(val name: String) {
     // Server implementations
     object Bukkit : PlatformType("Bukkit")
     object Minestom : PlatformType("Minestom")
+    object Fabric : PlatformType("Fabric")
 
     // Proxies
     object Velocity : PlatformType("Velocity")

--- a/platforms/fabric/build.gradle.kts
+++ b/platforms/fabric/build.gradle.kts
@@ -1,0 +1,96 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+plugins {
+    id("fabric-loom") version "0.9-SNAPSHOT"
+    id("net.kyori.blossom")
+}
+
+dependencies {
+    // https://fabricmc.net/versions.html
+    minecraft("com.mojang:minecraft:1.17.1")
+    mappings("net.fabricmc:yarn:1.17.1+build.61:v2")
+    modImplementation("net.fabricmc:fabric-loader:0.11.7")
+
+    modImplementation("net.fabricmc.fabric-api:fabric-api:0.40.1+1.17")
+    modImplementation("net.fabricmc:fabric-language-kotlin:1.6.5+kotlin.1.5.31")
+
+    api(project(":unifiedmetrics-core"))
+
+    include(project(":unifiedmetrics-core"))
+    include(project(":unifiedmetrics-common"))
+    include("com.charleskorn.kaml:kaml:0.36.0")
+    include("com.charleskorn.kaml:kaml-jvm:0.36.0")
+    include("org.snakeyaml:snakeyaml-engine:2.3")
+    include(project(":unifiedmetrics-api"))
+    include(project(":unifiedmetrics-driver-influx"))
+    include("com.influxdb:influxdb-client-java:3.3.0")
+    include("com.influxdb:influxdb-client-core:3.3.0")
+    include("com.influxdb:influxdb-client-utils:3.3.0")
+    include("com.google.code.findbugs:jsr305:3.0.2")
+    include("com.squareup.retrofit2:retrofit:2.9.0")
+    include("com.squareup.okhttp3:okhttp:4.7.2")
+    include("com.squareup.okio:okio:2.6.0")
+    include("com.squareup.okhttp3:logging-interceptor:4.7.2")
+    include("org.apache.commons:commons-csv:1.8")
+    include("io.reactivex.rxjava2:rxjava:2.2.19")
+    include("org.reactivestreams:reactive-streams:1.0.3")
+    include("io.swagger:swagger-annotations:1.6.1")
+    include("io.gsonfire:gson-fire:1.8.4")
+    include("com.squareup.retrofit2:converter-scalars:2.9.0")
+    include("com.squareup.retrofit2:converter-gson:2.9.0")
+    include(project(":unifiedmetrics-driver-prometheus"))
+    include("io.prometheus:simpleclient_httpserver:0.12.0")
+    include("io.prometheus:simpleclient:0.12.0")
+    include("io.prometheus:simpleclient_tracer_otel:0.12.0")
+    include("io.prometheus:simpleclient_tracer_common:0.12.0")
+    include("io.prometheus:simpleclient_tracer_otel_agent:0.12.0")
+    include("io.prometheus:simpleclient_common:0.12.0")
+    include("io.prometheus:simpleclient_pushgateway:0.12.0")
+}
+
+loom {
+    runs {
+        named("server") {
+            isIdeConfigGenerated = true
+        }
+    }
+}
+
+tasks {
+    compileKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+
+    processResources {
+        inputs.property("version", project.version)
+
+        filesMatching("fabric.mod.json") {
+            expand("version" to project.version)
+        }
+    }
+
+    compileJava {
+        options.encoding = "UTF-8"
+        options.release.set(8)
+    }
+}
+
+blossom {
+    replaceTokenIn("src/main/kotlin/dev/cubxity/plugins/metrics/fabric/bootstrap/UnifiedMetricsFabricBootstrap.kt")
+    replaceToken("@version@", version)
+}

--- a/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/MinecraftServerMixin.java
+++ b/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/MinecraftServerMixin.java
@@ -84,7 +84,7 @@ public class MinecraftServerMixin {
         )
     )
     private void onTickEnd(CallbackInfo ci) {
-        TickEvent.Companion.getEVENT().invoker().onTick((double)(System.nanoTime() - lastTick) / NANOSECONDS_PER_MILLISECOND);
+        TickEvent.Companion.getEvent().invoker().onTick((double)(System.nanoTime() - lastTick) / NANOSECONDS_PER_MILLISECOND);
     }
 
 }

--- a/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/MinecraftServerMixin.java
+++ b/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/MinecraftServerMixin.java
@@ -1,0 +1,90 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.fabric.mixins;
+
+import dev.cubxity.plugins.metrics.fabric.events.TickEvent;
+import net.minecraft.server.MinecraftServer;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static dev.cubxity.plugins.metrics.api.metric.collector.CollectorKt.NANOSECONDS_PER_MILLISECOND;
+import static dev.cubxity.plugins.metrics.api.metric.collector.CollectorKt.NANOSECONDS_PER_SECOND;
+
+/**
+ * Designed to emulate paper's tick event as closely as possible
+ */
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+
+    private long lastTick = 0;
+
+    @Inject(
+        method = "runServer",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/MinecraftServer;setFavicon(Lnet/minecraft/server/ServerMetadata;)V"
+        )
+    )
+    private void onRunServerBeforeLoop(CallbackInfo ci) {
+        lastTick = System.nanoTime() - ((long) NANOSECONDS_PER_SECOND / 20);
+    }
+
+    @Inject(
+        method = "runServer",
+        slice = @Slice(
+            from = @At(
+                value = "FIELD",
+                target = "Lnet/minecraft/server/MinecraftServer;debugStart:Lnet/minecraft/server/MinecraftServer$DebugStart;"
+            )
+        ),
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/server/MinecraftServer;timeReference:J",
+            opcode = Opcodes.PUTFIELD
+        )
+    )
+    private void onRunServerBeforeTick(CallbackInfo ci) {
+        lastTick = System.nanoTime();
+    }
+
+    @Inject(
+        method = "tick",
+        slice = @Slice(
+            from = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/util/snooper/Snooper;update()V"
+            ),
+            to = @At(
+                value = "FIELD",
+                target = "Lnet/minecraft/server/MinecraftServer;lastTickLengths:[J"
+            )
+        ),
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/util/profiler/Profiler;pop()V"
+        )
+    )
+    private void onTickEnd(CallbackInfo ci) {
+        TickEvent.Companion.getEVENT().invoker().onTick((double)(System.nanoTime() - lastTick) / NANOSECONDS_PER_MILLISECOND);
+    }
+
+}

--- a/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/ServerPlayNetworkHandlerMixin.java
+++ b/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/ServerPlayNetworkHandlerMixin.java
@@ -29,7 +29,7 @@ public class ServerPlayNetworkHandlerMixin {
 
     @Inject(method = "handleMessage", at = @At("HEAD"))
     private void onHandleMessage(CallbackInfo ci) {
-        ChatEvent.Companion.getEVENT().invoker().onChat();
+        ChatEvent.Companion.getEvent().invoker().onChat();
     }
 
 }

--- a/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/ServerPlayNetworkHandlerMixin.java
+++ b/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/ServerPlayNetworkHandlerMixin.java
@@ -15,19 +15,21 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.metric.collector
+package dev.cubxity.plugins.metrics.fabric.mixins;
 
-import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.fabric.events.ChatEvent;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-const val NANOSECONDS_PER_MILLISECOND: Double = 1E6
-const val NANOSECONDS_PER_SECOND: Double = 1E9
-const val MILLISECONDS_PER_SECOND: Double = 1E3
+@Mixin(ServerPlayNetworkHandler.class)
+public class ServerPlayNetworkHandlerMixin {
 
-interface Collector {
-    /**
-     * Collects the metric and returns a list of samples.
-     *
-     * @return [List] of [Metric]
-     */
-    fun collect(): List<Metric>
+    @Inject(method = "handleMessage", at = @At("HEAD"))
+    private void onHandleMessage(CallbackInfo ci) {
+        ChatEvent.Companion.getEVENT().invoker().onChat();
+    }
+
 }

--- a/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/ServerQueryNetworkHandlerMixin.java
+++ b/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/ServerQueryNetworkHandlerMixin.java
@@ -29,7 +29,7 @@ public class ServerQueryNetworkHandlerMixin {
 
     @Inject(method = "onRequest", at = @At("HEAD"))
     private void handleOnRequest(CallbackInfo ci) {
-        PingEvent.Companion.getEVENT().invoker().onPing();
+        PingEvent.Companion.getEvent().invoker().onPing();
     }
 
 }

--- a/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/ServerQueryNetworkHandlerMixin.java
+++ b/platforms/fabric/src/main/java/dev/cubxity/plugins/metrics/fabric/mixins/ServerQueryNetworkHandlerMixin.java
@@ -15,19 +15,21 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.metric.collector
+package dev.cubxity.plugins.metrics.fabric.mixins;
 
-import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.fabric.events.PingEvent;
+import net.minecraft.server.network.ServerQueryNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-const val NANOSECONDS_PER_MILLISECOND: Double = 1E6
-const val NANOSECONDS_PER_SECOND: Double = 1E9
-const val MILLISECONDS_PER_SECOND: Double = 1E3
+@Mixin(ServerQueryNetworkHandler.class)
+public class ServerQueryNetworkHandlerMixin {
 
-interface Collector {
-    /**
-     * Collects the metric and returns a list of samples.
-     *
-     * @return [List] of [Metric]
-     */
-    fun collect(): List<Metric>
+    @Inject(method = "onRequest", at = @At("HEAD"))
+    private void handleOnRequest(CallbackInfo ci) {
+        PingEvent.Companion.getEVENT().invoker().onPing();
+    }
+
 }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/UnifiedMetricsFabricPlugin.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/UnifiedMetricsFabricPlugin.kt
@@ -1,0 +1,49 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.fabric
+
+import dev.cubxity.plugins.metrics.api.UnifiedMetrics
+import dev.cubxity.plugins.metrics.core.plugin.CoreUnifiedMetricsPlugin
+import dev.cubxity.plugins.metrics.fabric.bootstrap.UnifiedMetricsFabricBootstrap
+import dev.cubxity.plugins.metrics.fabric.metrics.events.EventsCollection
+import dev.cubxity.plugins.metrics.fabric.metrics.server.ServerCollection
+import dev.cubxity.plugins.metrics.fabric.metrics.tick.TickCollection
+import dev.cubxity.plugins.metrics.fabric.metrics.world.WorldCollection
+import java.util.concurrent.Executors
+
+class UnifiedMetricsFabricPlugin(
+    override val bootstrap: UnifiedMetricsFabricBootstrap
+): CoreUnifiedMetricsPlugin() {
+
+    override fun registerPlatformService(api: UnifiedMetrics) {
+
+    }
+
+    override fun registerPlatformMetrics() {
+        super.registerPlatformMetrics()
+
+        apiProvider.metricsManager.apply {
+            with(config.metrics.collectors) {
+                if (server) registerCollection(ServerCollection(bootstrap))
+                if (world) registerCollection(WorldCollection(bootstrap))
+                if (tick) registerCollection(TickCollection())
+                if (events) registerCollection(EventsCollection())
+            }
+        }
+    }
+}

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/bootstrap/UnifiedMetricsFabricBootstrap.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/bootstrap/UnifiedMetricsFabricBootstrap.kt
@@ -1,0 +1,68 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.fabric.bootstrap
+
+import dev.cubxity.plugins.metrics.api.platform.PlatformType
+import dev.cubxity.plugins.metrics.common.UnifiedMetricsBootstrap
+import dev.cubxity.plugins.metrics.common.plugin.dispatcher.CurrentThreadDispatcher
+import dev.cubxity.plugins.metrics.fabric.UnifiedMetricsFabricPlugin
+import dev.cubxity.plugins.metrics.fabric.logger.Log4jLogger
+import kotlinx.coroutines.CoroutineDispatcher
+import net.fabricmc.api.DedicatedServerModInitializer
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
+import net.fabricmc.loader.api.FabricLoader
+import net.minecraft.server.MinecraftServer
+import org.apache.logging.log4j.LogManager
+import java.nio.file.Path
+
+private const val pluginVersion = "@version@"
+
+class UnifiedMetricsFabricBootstrap : DedicatedServerModInitializer, UnifiedMetricsBootstrap {
+    private val plugin = UnifiedMetricsFabricPlugin(this)
+    lateinit var server: MinecraftServer
+
+    override val type: PlatformType
+        get() = PlatformType.Fabric
+
+    override val version: String
+        get() = pluginVersion
+
+    override val serverBrand: String
+        get() = server.serverModName
+
+    override val dataDirectory: Path
+        = FabricLoader.getInstance().configDir.resolve("unifiedmetrics")
+
+    override val configDirectory: Path
+        = FabricLoader.getInstance().configDir.resolve("unifiedmetrics")
+
+    override val logger = Log4jLogger(LogManager.getLogger("UnifiedMetrics"))
+
+    override val dispatcher: CoroutineDispatcher = CurrentThreadDispatcher
+
+    override fun onInitializeServer() {
+        ServerLifecycleEvents.SERVER_STARTED.register {
+            server = it
+            plugin.enable()
+        }
+
+        ServerLifecycleEvents.SERVER_STOPPING.register {
+            plugin.disable()
+        }
+    }
+}

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/ChatEvent.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/ChatEvent.kt
@@ -25,7 +25,7 @@ fun interface ChatEvent {
     fun onChat()
 
     companion object {
-        val EVENT: Event<ChatEvent> = EventFactory.createArrayBacked(ChatEvent::class.java) { events ->
+        val event: Event<ChatEvent> = EventFactory.createArrayBacked(ChatEvent::class.java) { events ->
             ChatEvent {
                 events.forEach(ChatEvent::onChat)
             }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/ChatEvent.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/ChatEvent.kt
@@ -15,19 +15,21 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.metric.collector
+package dev.cubxity.plugins.metrics.fabric.events
 
-import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import net.fabricmc.fabric.api.event.Event
+import net.fabricmc.fabric.api.event.EventFactory
 
-const val NANOSECONDS_PER_MILLISECOND: Double = 1E6
-const val NANOSECONDS_PER_SECOND: Double = 1E9
-const val MILLISECONDS_PER_SECOND: Double = 1E3
+fun interface ChatEvent {
 
-interface Collector {
-    /**
-     * Collects the metric and returns a list of samples.
-     *
-     * @return [List] of [Metric]
-     */
-    fun collect(): List<Metric>
+    fun onChat()
+
+    companion object {
+        val EVENT: Event<ChatEvent> = EventFactory.createArrayBacked(ChatEvent::class.java) { events ->
+            ChatEvent {
+                events.forEach(ChatEvent::onChat)
+            }
+        }
+    }
+
 }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/PingEvent.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/PingEvent.kt
@@ -15,19 +15,21 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.metric.collector
+package dev.cubxity.plugins.metrics.fabric.events
 
-import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import net.fabricmc.fabric.api.event.Event
+import net.fabricmc.fabric.api.event.EventFactory
 
-const val NANOSECONDS_PER_MILLISECOND: Double = 1E6
-const val NANOSECONDS_PER_SECOND: Double = 1E9
-const val MILLISECONDS_PER_SECOND: Double = 1E3
+fun interface PingEvent {
 
-interface Collector {
-    /**
-     * Collects the metric and returns a list of samples.
-     *
-     * @return [List] of [Metric]
-     */
-    fun collect(): List<Metric>
+    fun onPing()
+
+    companion object {
+        val EVENT: Event<PingEvent> = EventFactory.createArrayBacked(PingEvent::class.java) { events ->
+            PingEvent {
+                events.forEach(PingEvent::onPing)
+            }
+        }
+    }
+
 }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/PingEvent.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/PingEvent.kt
@@ -25,7 +25,7 @@ fun interface PingEvent {
     fun onPing()
 
     companion object {
-        val EVENT: Event<PingEvent> = EventFactory.createArrayBacked(PingEvent::class.java) { events ->
+        val event: Event<PingEvent> = EventFactory.createArrayBacked(PingEvent::class.java) { events ->
             PingEvent {
                 events.forEach(PingEvent::onPing)
             }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/TickEvent.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/TickEvent.kt
@@ -26,7 +26,7 @@ fun interface TickEvent {
 
     companion object {
 
-        val EVENT: Event<TickEvent> = EventFactory.createArrayBacked(TickEvent::class.java) { events ->
+        val event: Event<TickEvent> = EventFactory.createArrayBacked(TickEvent::class.java) { events ->
             TickEvent { tickTime ->
                 events.forEach { it.onTick(tickTime) }
             }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/TickEvent.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/events/TickEvent.kt
@@ -15,19 +15,23 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.metric.collector
+package dev.cubxity.plugins.metrics.fabric.events
 
-import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import net.fabricmc.fabric.api.event.Event
+import net.fabricmc.fabric.api.event.EventFactory
 
-const val NANOSECONDS_PER_MILLISECOND: Double = 1E6
-const val NANOSECONDS_PER_SECOND: Double = 1E9
-const val MILLISECONDS_PER_SECOND: Double = 1E3
+fun interface TickEvent {
 
-interface Collector {
-    /**
-     * Collects the metric and returns a list of samples.
-     *
-     * @return [List] of [Metric]
-     */
-    fun collect(): List<Metric>
+    fun onTick(tickTime: Double)
+
+    companion object {
+
+        val EVENT: Event<TickEvent> = EventFactory.createArrayBacked(TickEvent::class.java) { events ->
+            TickEvent { tickTime ->
+                events.forEach { it.onTick(tickTime) }
+            }
+        }
+
+    }
+
 }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/logger/Log4jLogger.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/logger/Log4jLogger.kt
@@ -15,19 +15,29 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.metric.collector
+package dev.cubxity.plugins.metrics.fabric.logger
 
-import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.api.logging.Logger
+import org.apache.logging.log4j.Level
 
-const val NANOSECONDS_PER_MILLISECOND: Double = 1E6
-const val NANOSECONDS_PER_SECOND: Double = 1E9
-const val MILLISECONDS_PER_SECOND: Double = 1E3
+class Log4jLogger(private val logger: org.apache.logging.log4j.Logger): Logger {
+    override fun info(message: String) {
+        logger.log(Level.INFO, message)
+    }
 
-interface Collector {
-    /**
-     * Collects the metric and returns a list of samples.
-     *
-     * @return [List] of [Metric]
-     */
-    fun collect(): List<Metric>
+    override fun warn(message: String) {
+        logger.log(Level.WARN, message)
+    }
+
+    override fun warn(message: String, error: Throwable) {
+        logger.log(Level.WARN, message, error)
+    }
+
+    override fun severe(message: String) {
+        logger.log(Level.ERROR, message)
+    }
+
+    override fun severe(message: String, error: Throwable) {
+        logger.log(Level.ERROR, message, error)
+    }
 }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/events/EventsCollection.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/events/EventsCollection.kt
@@ -47,10 +47,10 @@ class EventsCollection : CollectorCollection {
         ServerPlayConnectionEvents.DISCONNECT.register { _, _ ->
             quitCounter.inc()
         }
-        ChatEvent.EVENT.register {
+        ChatEvent.event.register {
             chatCounter.inc()
         }
-        PingEvent.EVENT.register {
+        PingEvent.event.register {
             pingCounter.inc()
         }
     }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/events/EventsCollection.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/events/EventsCollection.kt
@@ -1,0 +1,57 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.fabric.metrics.events
+
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
+import dev.cubxity.plugins.metrics.api.metric.collector.Counter
+import dev.cubxity.plugins.metrics.api.metric.store.VolatileDoubleStore
+import dev.cubxity.plugins.metrics.common.metric.Metrics
+import dev.cubxity.plugins.metrics.fabric.events.ChatEvent
+import dev.cubxity.plugins.metrics.fabric.events.PingEvent
+import net.fabricmc.fabric.api.networking.v1.ServerLoginConnectionEvents
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents
+
+class EventsCollection : CollectorCollection {
+    private val loginCounter = Counter(Metrics.Events.Login)
+    private val joinCounter = Counter(Metrics.Events.Join)
+    private val quitCounter = Counter(Metrics.Events.Quit)
+    private val chatCounter = Counter(Metrics.Events.Chat, valueStoreFactory = VolatileDoubleStore)
+    private val pingCounter = Counter(Metrics.Events.Ping)
+
+    override val collectors: List<Collector> =
+        listOf(loginCounter, joinCounter, quitCounter, chatCounter, pingCounter)
+
+    override fun initialize() {
+        ServerLoginConnectionEvents.INIT.register { _, _ ->
+            loginCounter.inc()
+        }
+        ServerPlayConnectionEvents.JOIN.register { _, _, _ ->
+            joinCounter.inc()
+        }
+        ServerPlayConnectionEvents.DISCONNECT.register { _, _ ->
+            quitCounter.inc()
+        }
+        ChatEvent.EVENT.register {
+            chatCounter.inc()
+        }
+        PingEvent.EVENT.register {
+            pingCounter.inc()
+        }
+    }
+}

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/server/ServerCollection.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/server/ServerCollection.kt
@@ -15,19 +15,12 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.metric.collector
+package dev.cubxity.plugins.metrics.fabric.metrics.server
 
-import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
+import dev.cubxity.plugins.metrics.fabric.bootstrap.UnifiedMetricsFabricBootstrap
 
-const val NANOSECONDS_PER_MILLISECOND: Double = 1E6
-const val NANOSECONDS_PER_SECOND: Double = 1E9
-const val MILLISECONDS_PER_SECOND: Double = 1E3
-
-interface Collector {
-    /**
-     * Collects the metric and returns a list of samples.
-     *
-     * @return [List] of [Metric]
-     */
-    fun collect(): List<Metric>
+class ServerCollection(bootstrap: UnifiedMetricsFabricBootstrap) : CollectorCollection {
+    override val collectors: List<Collector> = listOf(ServerCollector(bootstrap))
 }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/server/ServerCollector.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/server/ServerCollector.kt
@@ -1,0 +1,36 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.fabric.metrics.server
+
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.data.GaugeMetric
+import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.common.metric.Metrics
+import dev.cubxity.plugins.metrics.fabric.bootstrap.UnifiedMetricsFabricBootstrap
+import net.fabricmc.loader.api.FabricLoader
+
+class ServerCollector(private val bootstrap: UnifiedMetricsFabricBootstrap): Collector {
+    override fun collect(): List<Metric> {
+        val server = bootstrap.server
+        return listOf(
+            GaugeMetric(Metrics.Server.Plugins, value = FabricLoader.getInstance().allMods.size),
+            GaugeMetric(Metrics.Server.PlayersCount, value = server.currentPlayerCount),
+            GaugeMetric(Metrics.Server.PlayersMax, value = server.maxPlayerCount)
+        )
+    }
+}

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/tick/TickCollection.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/tick/TickCollection.kt
@@ -23,11 +23,12 @@ import dev.cubxity.plugins.metrics.api.metric.collector.Histogram
 import dev.cubxity.plugins.metrics.api.metric.collector.MILLISECONDS_PER_SECOND
 import dev.cubxity.plugins.metrics.api.metric.store.VolatileDoubleStore
 import dev.cubxity.plugins.metrics.api.metric.store.VolatileLongStore
+import dev.cubxity.plugins.metrics.common.metric.Metrics
 import dev.cubxity.plugins.metrics.fabric.events.TickEvent
 
 class TickCollection : CollectorCollection {
     private val tickDuration = Histogram(
-        "minecraft_tick_duration_seconds",
+        Metrics.Server.TickDurationSeconds,
         sumStoreFactory = VolatileDoubleStore,
         countStoreFactory = VolatileLongStore
     )
@@ -36,7 +37,7 @@ class TickCollection : CollectorCollection {
 
 
     override fun initialize() {
-        TickEvent.EVENT.register { duration ->
+        TickEvent.event.register { duration ->
             onTick(duration / MILLISECONDS_PER_SECOND)
         }
     }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/tick/TickCollection.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/tick/TickCollection.kt
@@ -1,0 +1,47 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.fabric.metrics.tick
+
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
+import dev.cubxity.plugins.metrics.api.metric.collector.Histogram
+import dev.cubxity.plugins.metrics.api.metric.collector.MILLISECONDS_PER_SECOND
+import dev.cubxity.plugins.metrics.api.metric.store.VolatileDoubleStore
+import dev.cubxity.plugins.metrics.api.metric.store.VolatileLongStore
+import dev.cubxity.plugins.metrics.fabric.events.TickEvent
+
+class TickCollection : CollectorCollection {
+    private val tickDuration = Histogram(
+        "minecraft_tick_duration_seconds",
+        sumStoreFactory = VolatileDoubleStore,
+        countStoreFactory = VolatileLongStore
+    )
+
+    override val collectors: List<Collector> = listOf(tickDuration)
+
+
+    override fun initialize() {
+        TickEvent.EVENT.register { duration ->
+            onTick(duration / MILLISECONDS_PER_SECOND)
+        }
+    }
+
+    fun onTick(duration: Double) {
+        tickDuration += duration
+    }
+}

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/world/WorldCollection.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/world/WorldCollection.kt
@@ -15,19 +15,12 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.metric.collector
+package dev.cubxity.plugins.metrics.fabric.metrics.world
 
-import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
+import dev.cubxity.plugins.metrics.fabric.bootstrap.UnifiedMetricsFabricBootstrap
 
-const val NANOSECONDS_PER_MILLISECOND: Double = 1E6
-const val NANOSECONDS_PER_SECOND: Double = 1E9
-const val MILLISECONDS_PER_SECOND: Double = 1E3
-
-interface Collector {
-    /**
-     * Collects the metric and returns a list of samples.
-     *
-     * @return [List] of [Metric]
-     */
-    fun collect(): List<Metric>
+class WorldCollection(bootstrap: UnifiedMetricsFabricBootstrap) : CollectorCollection {
+    override val collectors: List<Collector> = listOf(WorldCollector(bootstrap))
 }

--- a/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/world/WorldCollector.kt
+++ b/platforms/fabric/src/main/kotlin/dev/cubxity/plugins/metrics/fabric/metrics/world/WorldCollector.kt
@@ -1,0 +1,40 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.fabric.metrics.world
+
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.data.GaugeMetric
+import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.common.metric.Metrics
+import dev.cubxity.plugins.metrics.fabric.bootstrap.UnifiedMetricsFabricBootstrap
+
+class WorldCollector(private val bootstrap: UnifiedMetricsFabricBootstrap) : Collector {
+    override fun collect(): List<Metric> {
+        val worlds = bootstrap.server.worlds
+        val samples = ArrayList<Metric>(worlds.count() * 3)
+
+        worlds.forEach { world ->
+            val tags = mapOf("world" to world.registryKey.value.toString())
+            samples.add(GaugeMetric(Metrics.Server.WorldEntitiesCount, tags, world.iterateEntities().count()))
+            samples.add(GaugeMetric(Metrics.Server.WorldPlayersCount, tags, world.players.size))
+            samples.add(GaugeMetric(Metrics.Server.WorldLoadedChunks, tags, world.chunkManager.totalChunksLoadedCount))
+        }
+
+        return samples
+    }
+}

--- a/platforms/fabric/src/main/resources/fabric.mod.json
+++ b/platforms/fabric/src/main/resources/fabric.mod.json
@@ -1,0 +1,35 @@
+{
+    "schemaVersion": 1,
+    "id": "unifiedmetrics",
+    "version": "${version}",
+
+    "name": "Unified Metrics",
+    "description": "Fully-featured metrics plugin for Minecraft servers",
+    "authors": [
+        "Cubxity"
+    ],
+    "contact": {
+        "homepage": "https://github.com/Cubxity/UnifiedMetrics/",
+        "sources": "https://github.com/Cubxity/UnifiedMetrics/",
+        "issues": "https://github.com/Cubxity/UnifiedMetrics/issues"
+    },
+
+    "license": "LGPL-3.0",
+
+    "environment": "server",
+    "entrypoints": {
+        "server": [
+            "dev.cubxity.plugins.metrics.fabric.bootstrap.UnifiedMetricsFabricBootstrap"
+        ]
+    },
+    "mixins": [
+        "unifiedmetrics.mixins.json"
+    ],
+
+    "depends": {
+        "fabricloader": ">=0.11.3",
+        "fabric": "*",
+        "minecraft": ">=1.16",
+        "fabric-language-kotlin": ">=1.6.0+kotlin.1.5.0"
+    }
+}

--- a/platforms/fabric/src/main/resources/unifiedmetrics.mixins.json
+++ b/platforms/fabric/src/main/resources/unifiedmetrics.mixins.json
@@ -1,0 +1,11 @@
+{
+    "required": true,
+    "minVersion": "0.8",
+    "package": "dev.cubxity.plugins.metrics.fabric.mixins",
+    "compatibilityLevel": "JAVA_8",
+    "mixins": [
+        "ServerPlayNetworkHandlerMixin",
+        "ServerQueryNetworkHandlerMixin",
+        "MinecraftServerMixin"
+    ]
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ include(modulePrefix + platformPrefix + "bukkit")
 include(modulePrefix + platformPrefix + "minestom")
 include(modulePrefix + platformPrefix + "velocity")
 include(modulePrefix + platformPrefix + "bungee")
+include(modulePrefix + platformPrefix + "fabric")
 
 include(modulePrefix + driverPrefix + "influx")
 include(modulePrefix + driverPrefix + "prometheus")
@@ -42,7 +43,18 @@ project(modulePrefix + platformPrefix + "bukkit").projectDir = File(platformsDir
 project(modulePrefix + platformPrefix + "minestom").projectDir = File(platformsDir, "minestom")
 project(modulePrefix + platformPrefix + "velocity").projectDir = File(platformsDir, "velocity")
 project(modulePrefix + platformPrefix + "bungee").projectDir = File(platformsDir, "bungee")
+project(modulePrefix + platformPrefix + "fabric").projectDir = File(platformsDir, "fabric")
 
 val driversDir = File(rootDir, "drivers")
 project(modulePrefix + driverPrefix + "influx").projectDir = File(driversDir, "influx")
 project(modulePrefix + driverPrefix + "prometheus").projectDir = File(driversDir, "prometheus")
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven {
+            name = "Fabric"
+            url = uri("https://maven.fabricmc.net/")
+        }
+    }
+}


### PR DESCRIPTION
Adds support for fabric servers. Requires `fabric` (fabric api), `fabric-language-kotlin`, and Minecraft 1.16 or above.

Resolves #11.