### PR TITLE
Added Krypton support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Click [here](https://dedimc.link/unifiedmetrics) for live preview!
 - Minestom
 - Velocity
 - BungeeCord
+- Krypton
 
 **Metrics:**
 
@@ -44,16 +45,16 @@ Read the [wiki](https://github.com/Cubxity/UnifiedMetrics/wiki) for instructions
 <details> 
   <summary>Table of metrics (click to show)</summary>
 
-| Collector     | Description                                     | Platform            | Default |
-| ------------- | ----------------------------------------------- | ------------------- | ------- |
-| systemGc      | Garbage collection duration and freed bytes     | All                 | true    |
-| systemMemory  | Memory used, committed, max and init            | All                 | true    |
-| systemProcess | CPU load, seconds, and process start time       | All                 | true    |
-| systemThread  | Current, daemon, started, and peak thread count | All                 | true    |
-| events        | Login, join, quit, chat, and ping event counter | All                 | true    |
-| server        | Plugins count and player counts                 | All                 | true    |
-| tick          | Tick duration histogram                         | Bukkit, Minestom    | true    |
-| world         | World entities, players, and chunks count       | Bukkit, Minestom    | true    |
+| Collector     | Description                                     | Platform                     | Default |
+| ------------- | ----------------------------------------------- | ---------------------------- | ------- |
+| systemGc      | Garbage collection duration and freed bytes     | All                          | true    |
+| systemMemory  | Memory used, committed, max and init            | All                          | true    |
+| systemProcess | CPU load, seconds, and process start time       | All                          | true    |
+| systemThread  | Current, daemon, started, and peak thread count | All                          | true    |
+| events        | Login, join, quit, chat, and ping event counter | All                          | true    |
+| server        | Plugins count and player counts                 | All                          | true    |
+| tick          | Tick duration histogram                         | Bukkit, Minestom, Krypton    | true    |
+| world         | World entities, players, and chunks count       | Bukkit, Minestom, Krypton    | true    |
 
 </details>
 
@@ -99,7 +100,7 @@ and [YourKit YouMonitor](https://www.yourkit.com/youmonitor/).
 
 **Requirements:**
 
-- JDK 8+ (16+ for Fabric, 17+ for Minestom)
+- JDK 8+ (16+ for Fabric, 17+ for Minestom and Krypton)
 - Git (Optional)
 
 To build UnifiedMetrics, you need to obtain the source code first. You can download the source from GitHub or use the

--- a/platforms/krypton/build.gradle.kts
+++ b/platforms/krypton/build.gradle.kts
@@ -15,16 +15,33 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.platform
+plugins {
+    kotlin("kapt")
+    id("com.github.johnrengelman.shadow")
+    id("net.kyori.blossom")
+}
 
-sealed class PlatformType(val name: String) {
-    // Server implementations
-    object Bukkit : PlatformType("Bukkit")
-    object Minestom : PlatformType("Minestom")
-    object Fabric : PlatformType("Fabric")
-    object Krypton : PlatformType("Krypton")
+repositories {
+    maven("https://repo.kryptonmc.org/releases")
+}
 
-    // Proxies
-    object Velocity : PlatformType("Velocity")
-    object BungeeCord : PlatformType("BungeeCord")
+dependencies {
+    api(project(":unifiedmetrics-core"))
+
+    compileOnly("org.kryptonmc:krypton-api:0.60.2")
+    kapt("org.kryptonmc:krypton-annotation-processor:0.60.2")
+}
+
+tasks {
+    compileKotlin {
+        kotlinOptions.jvmTarget = "17"
+    }
+    shadowJar {
+        archiveClassifier.set("")
+    }
+}
+
+blossom {
+    replaceTokenIn("src/main/kotlin/dev/cubxity/plugins/metrics/krypton/bootstrap/UnifiedMetricsKryptonBootstrap.kt")
+    replaceToken("@version@", version)
 }

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/UnifiedMetricsKryptonPlugin.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/UnifiedMetricsKryptonPlugin.kt
@@ -1,0 +1,46 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.krypton
+
+import dev.cubxity.plugins.metrics.api.UnifiedMetrics
+import dev.cubxity.plugins.metrics.core.plugin.CoreUnifiedMetricsPlugin
+import dev.cubxity.plugins.metrics.krypton.bootstrap.UnifiedMetricsKryptonBootstrap
+import dev.cubxity.plugins.metrics.krypton.metric.events.EventsCollection
+import dev.cubxity.plugins.metrics.krypton.metric.server.ServerCollection
+import dev.cubxity.plugins.metrics.krypton.metric.tick.TickCollection
+import dev.cubxity.plugins.metrics.krypton.metric.world.WorldCollection
+import org.kryptonmc.api.service.register
+
+class UnifiedMetricsKryptonPlugin(override val bootstrap: UnifiedMetricsKryptonBootstrap) : CoreUnifiedMetricsPlugin() {
+    override fun registerPlatformService(api: UnifiedMetrics) {
+        bootstrap.server.servicesManager.register(bootstrap, api)
+    }
+
+    override fun registerPlatformMetrics() {
+        super.registerPlatformMetrics()
+
+        apiProvider.metricsManager.apply {
+            with(config.metrics.collectors) {
+                if (server) registerCollection(ServerCollection(bootstrap))
+                if (world) registerCollection(WorldCollection(bootstrap))
+                if (tick) registerCollection(TickCollection(bootstrap))
+                if (events) registerCollection(EventsCollection(bootstrap))
+            }
+        }
+    }
+}

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/bootstrap/UnifiedMetricsKryptonBootstrap.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/bootstrap/UnifiedMetricsKryptonBootstrap.kt
@@ -1,0 +1,78 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.krypton.bootstrap
+
+import com.google.inject.Inject
+import dev.cubxity.plugins.metrics.api.platform.PlatformType
+import dev.cubxity.plugins.metrics.common.UnifiedMetricsBootstrap
+import dev.cubxity.plugins.metrics.common.plugin.dispatcher.CurrentThreadDispatcher
+import dev.cubxity.plugins.metrics.krypton.UnifiedMetricsKryptonPlugin
+import dev.cubxity.plugins.metrics.krypton.logger.Log4JLogger
+import kotlinx.coroutines.CoroutineDispatcher
+import org.kryptonmc.api.Server
+import org.kryptonmc.api.event.Listener
+import org.kryptonmc.api.event.ListenerPriority
+import org.kryptonmc.api.event.server.ServerStartEvent
+import org.kryptonmc.api.event.server.ServerStopEvent
+import org.kryptonmc.api.plugin.annotation.DataFolder
+import org.kryptonmc.api.plugin.annotation.Plugin
+import java.nio.file.Path
+
+private const val pluginVersion = "@version@"
+
+@Plugin(
+    "unifiedmetrics",
+    "UnifiedMetrics",
+    pluginVersion,
+    "Fully-featured metrics plugin for Minecraft servers",
+    ["Cubxity"]
+)
+class UnifiedMetricsKryptonBootstrap @Inject constructor(
+    @DataFolder
+    override val dataDirectory: Path,
+    val server: Server,
+    pluginLogger: org.apache.logging.log4j.Logger
+) : UnifiedMetricsBootstrap {
+    private val plugin = UnifiedMetricsKryptonPlugin(this)
+
+    override val type: PlatformType
+        get() = PlatformType.Krypton
+
+    override val version: String
+        get() = pluginVersion
+
+    override val serverBrand: String
+        get() = server.platform.name
+
+    override val configDirectory: Path
+        get() = dataDirectory
+
+    override val logger = Log4JLogger(pluginLogger)
+
+    override val dispatcher: CoroutineDispatcher = CurrentThreadDispatcher
+
+    @Listener(ListenerPriority.MAXIMUM)
+    fun onStart(event: ServerStartEvent) {
+        plugin.enable()
+    }
+
+    @Listener(ListenerPriority.NONE)
+    fun onStop(event: ServerStopEvent) {
+        plugin.disable()
+    }
+}

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/logger/Log4JLogger.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/logger/Log4JLogger.kt
@@ -15,16 +15,28 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.platform
+package dev.cubxity.plugins.metrics.krypton.logger
 
-sealed class PlatformType(val name: String) {
-    // Server implementations
-    object Bukkit : PlatformType("Bukkit")
-    object Minestom : PlatformType("Minestom")
-    object Fabric : PlatformType("Fabric")
-    object Krypton : PlatformType("Krypton")
+import dev.cubxity.plugins.metrics.api.logging.Logger
 
-    // Proxies
-    object Velocity : PlatformType("Velocity")
-    object BungeeCord : PlatformType("BungeeCord")
+class Log4JLogger(private val logger: org.apache.logging.log4j.Logger) : Logger {
+    override fun info(message: String) {
+        logger.info(message)
+    }
+
+    override fun warn(message: String) {
+        logger.warn(message)
+    }
+
+    override fun warn(message: String, error: Throwable) {
+        logger.warn(message, error)
+    }
+
+    override fun severe(message: String) {
+        logger.error(message)
+    }
+
+    override fun severe(message: String, error: Throwable) {
+        logger.error(message, error)
+    }
 }

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/events/EventsCollection.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/events/EventsCollection.kt
@@ -1,0 +1,70 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.krypton.metric.events
+
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
+import dev.cubxity.plugins.metrics.api.metric.collector.Counter
+import dev.cubxity.plugins.metrics.api.metric.store.VolatileDoubleStore
+import dev.cubxity.plugins.metrics.common.metric.Metrics
+import dev.cubxity.plugins.metrics.krypton.bootstrap.UnifiedMetricsKryptonBootstrap
+import org.kryptonmc.api.event.Listener
+import org.kryptonmc.api.event.player.ChatEvent
+import org.kryptonmc.api.event.player.JoinEvent
+import org.kryptonmc.api.event.player.LoginEvent
+import org.kryptonmc.api.event.player.QuitEvent
+
+class EventsCollection(private val bootstrap: UnifiedMetricsKryptonBootstrap) : CollectorCollection {
+    private val loginCounter = Counter(Metrics.Events.Login)
+    private val joinCounter = Counter(Metrics.Events.Join, valueStoreFactory = VolatileDoubleStore)
+    private val quitCounter = Counter(Metrics.Events.Quit, valueStoreFactory = VolatileDoubleStore)
+    private val chatCounter = Counter(Metrics.Events.Chat)
+
+    override val collectors: List<Collector> = listOf(loginCounter, joinCounter, quitCounter, chatCounter)
+
+    override val isAsync: Boolean
+        get() = true
+
+    override fun initialize() {
+        bootstrap.server.eventManager.register(bootstrap, this)
+    }
+
+    override fun dispose() {
+        bootstrap.server.eventManager.unregisterListener(bootstrap, this)
+    }
+
+    @Listener
+    fun onLogin(event: LoginEvent) {
+        loginCounter.inc()
+    }
+
+    @Listener
+    fun onJoin(event: JoinEvent) {
+        joinCounter.inc()
+    }
+
+    @Listener
+    fun onQuit(event: QuitEvent) {
+        quitCounter.inc()
+    }
+
+    @Listener
+    fun onChat(event: ChatEvent) {
+        chatCounter.inc()
+    }
+}

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/server/ServerCollection.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/server/ServerCollection.kt
@@ -15,16 +15,12 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.platform
+package dev.cubxity.plugins.metrics.krypton.metric.server
 
-sealed class PlatformType(val name: String) {
-    // Server implementations
-    object Bukkit : PlatformType("Bukkit")
-    object Minestom : PlatformType("Minestom")
-    object Fabric : PlatformType("Fabric")
-    object Krypton : PlatformType("Krypton")
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
+import dev.cubxity.plugins.metrics.krypton.bootstrap.UnifiedMetricsKryptonBootstrap
 
-    // Proxies
-    object Velocity : PlatformType("Velocity")
-    object BungeeCord : PlatformType("BungeeCord")
+class ServerCollection(bootstrap: UnifiedMetricsKryptonBootstrap) : CollectorCollection {
+    override val collectors: List<Collector> = listOf(ServerCollector(bootstrap))
 }

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/server/ServerCollector.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/server/ServerCollector.kt
@@ -1,0 +1,35 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.krypton.metric.server
+
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.data.GaugeMetric
+import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.common.metric.Metrics
+import dev.cubxity.plugins.metrics.krypton.bootstrap.UnifiedMetricsKryptonBootstrap
+
+class ServerCollector(private val bootstrap: UnifiedMetricsKryptonBootstrap) : Collector {
+    override fun collect(): List<Metric> {
+        val server = bootstrap.server
+        return listOf(
+            GaugeMetric(Metrics.Server.Plugins, value = server.pluginManager.plugins.size),
+            GaugeMetric(Metrics.Server.PlayersCount, value = server.players.size),
+            GaugeMetric(Metrics.Server.PlayersMax, value = server.maxPlayers)
+        )
+    }
+}

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/tick/TickCollection.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/tick/TickCollection.kt
@@ -1,0 +1,55 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.krypton.metric.tick
+
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
+import dev.cubxity.plugins.metrics.api.metric.collector.Histogram
+import dev.cubxity.plugins.metrics.api.metric.collector.MILLISECONDS_PER_SECOND
+import dev.cubxity.plugins.metrics.api.metric.store.VolatileDoubleStore
+import dev.cubxity.plugins.metrics.api.metric.store.VolatileLongStore
+import dev.cubxity.plugins.metrics.common.metric.Metrics
+import dev.cubxity.plugins.metrics.krypton.bootstrap.UnifiedMetricsKryptonBootstrap
+import org.kryptonmc.api.event.Listener
+import org.kryptonmc.api.event.server.TickEndEvent
+
+class TickCollection(private val bootstrap: UnifiedMetricsKryptonBootstrap) : CollectorCollection {
+    private val tickDuration = Histogram(
+        Metrics.Server.TickDurationSeconds,
+        sumStoreFactory = VolatileDoubleStore,
+        countStoreFactory = VolatileLongStore
+    )
+
+    override val collectors: List<Collector> = listOf(tickDuration)
+
+    override val isAsync: Boolean
+        get() = true
+
+    override fun initialize() {
+        bootstrap.server.eventManager.register(bootstrap, this)
+    }
+
+    override fun dispose() {
+        bootstrap.server.eventManager.unregisterListener(bootstrap, this)
+    }
+
+    @Listener
+    fun onTick(event: TickEndEvent) {
+        tickDuration += (event.tickDuration / MILLISECONDS_PER_SECOND)
+    }
+}

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/world/WorldCollection.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/world/WorldCollection.kt
@@ -15,16 +15,14 @@
  *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package dev.cubxity.plugins.metrics.api.platform
+package dev.cubxity.plugins.metrics.krypton.metric.world
 
-sealed class PlatformType(val name: String) {
-    // Server implementations
-    object Bukkit : PlatformType("Bukkit")
-    object Minestom : PlatformType("Minestom")
-    object Fabric : PlatformType("Fabric")
-    object Krypton : PlatformType("Krypton")
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
+import dev.cubxity.plugins.metrics.krypton.bootstrap.UnifiedMetricsKryptonBootstrap
 
-    // Proxies
-    object Velocity : PlatformType("Velocity")
-    object BungeeCord : PlatformType("BungeeCord")
+class WorldCollection(bootstrap: UnifiedMetricsKryptonBootstrap) : CollectorCollection {
+    private val collector = WorldCollector(bootstrap)
+
+    override val collectors: List<Collector> = listOf(collector)
 }

--- a/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/world/WorldCollector.kt
+++ b/platforms/krypton/src/main/kotlin/dev/cubxity/plugins/metrics/krypton/metric/world/WorldCollector.kt
@@ -1,0 +1,40 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.krypton.metric.world
+
+import dev.cubxity.plugins.metrics.api.metric.collector.Collector
+import dev.cubxity.plugins.metrics.api.metric.data.GaugeMetric
+import dev.cubxity.plugins.metrics.api.metric.data.Metric
+import dev.cubxity.plugins.metrics.common.metric.Metrics
+import dev.cubxity.plugins.metrics.krypton.bootstrap.UnifiedMetricsKryptonBootstrap
+
+class WorldCollector(private val bootstrap: UnifiedMetricsKryptonBootstrap) : Collector {
+    override fun collect(): List<Metric> {
+        val worlds = bootstrap.server.worldManager.worlds.values
+        val samples = ArrayList<Metric>(worlds.size * 3)
+
+        worlds.forEach { world ->
+            val tags = mapOf("world" to world.name)
+            samples.add(GaugeMetric(Metrics.Server.WorldEntitiesCount, tags, world.entities.size))
+            samples.add(GaugeMetric(Metrics.Server.WorldPlayersCount, tags, world.players.size))
+            samples.add(GaugeMetric(Metrics.Server.WorldLoadedChunks, tags, world.chunks.size))
+        }
+
+        return samples
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include(modulePrefix + platformPrefix + "minestom")
 include(modulePrefix + platformPrefix + "velocity")
 include(modulePrefix + platformPrefix + "bungee")
 include(modulePrefix + platformPrefix + "fabric")
+include(modulePrefix + platformPrefix + "krypton")
 
 include(modulePrefix + driverPrefix + "influx")
 include(modulePrefix + driverPrefix + "prometheus")
@@ -44,6 +45,7 @@ project(modulePrefix + platformPrefix + "minestom").projectDir = File(platformsD
 project(modulePrefix + platformPrefix + "velocity").projectDir = File(platformsDir, "velocity")
 project(modulePrefix + platformPrefix + "bungee").projectDir = File(platformsDir, "bungee")
 project(modulePrefix + platformPrefix + "fabric").projectDir = File(platformsDir, "fabric")
+project(modulePrefix + platformPrefix + "krypton").projectDir = File(platformsDir, "krypton")
 
 val driversDir = File(rootDir, "drivers")
 project(modulePrefix + driverPrefix + "influx").projectDir = File(driversDir, "influx")


### PR DESCRIPTION
This pull request adds support for Krypton, which is Minecraft server software written from scratch. If you've never heard of it, it's kinda similar to Minestom, but unlike Minestom, it's aimed at reimplementing vanilla.
It's written in Kotlin, which goes very nicely with this project.

I've tested this, and it seems to work fine. The endpoints resolve properly, and the metrics are there. I mean, the implementation is based off of the Bukkit and Velocity implementations, so I'd expect it to work fine, since most of the code is identical to those.

I also offer to fully maintain support for this platform if you want.

Anyway, if you have any questions, feel free to ask away. If you want to local test this, you can download Krypton [here](https://ci.kryptonmc.org/job/Krypton).