### PR TITLE
Remove dead server from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,6 @@ and [YourKit YouMonitor](https://www.yourkit.com/youmonitor/).
       width="200"
     />
   </a>
-  <a href="https://octanemc.net">
-    <img
-      src="https://octanemc.net/assets/images/logo-large.png"
-      alt="OctaneMC"
-      width="200"
-    />
-  </a>
 </p>
 
 > **Pssst!** You can add your server here by submitting a *Pull Request*!


### PR DESCRIPTION
The domain has expired, so the logo won't load.