### PR TITLE
feat(prometheus): add custom groupingKey support for PushGateway

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
 allprojects {
     group = "dev.cubxity.plugins"
     description = "Fully featured metrics collector agent for Minecraft servers."
-    version = "0.3.10-SNAPSHOT"
+    version = "0.3.11-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/drivers/prometheus/src/main/kotlin/dev/cubxity/plugins/metrics/prometheus/config/PrometheusConfig.kt
+++ b/drivers/prometheus/src/main/kotlin/dev/cubxity/plugins/metrics/prometheus/config/PrometheusConfig.kt
@@ -48,7 +48,8 @@ data class PushGatewayConfig(
     val job: String = "unifiedmetrics",
     val url: String = "http://pushgateway:9091",
     val authentication: AuthenticationConfig = AuthenticationConfig(),
-    val interval: Long = 10
+    val interval: Long = 10,
+    val groupingKey: Map<String, String> = emptyMap()
 )
 
 @Serializable

--- a/drivers/prometheus/src/main/kotlin/dev/cubxity/plugins/metrics/prometheus/exporter/PushGatewayExporter.kt
+++ b/drivers/prometheus/src/main/kotlin/dev/cubxity/plugins/metrics/prometheus/exporter/PushGatewayExporter.kt
@@ -33,7 +33,8 @@ class PushGatewayExporter(
     private val driver: PrometheusMetricsDriver
 ) : PrometheusExporter {
     private val coroutineScope = CoroutineScope(Dispatchers.IO) + SupervisorJob()
-    private val groupingKey = mapOf("server" to api.serverName)
+    private val groupingKey: Map<String, String>
+        get() = mapOf("server" to api.serverName) + driver.config.pushGateway.groupingKey
 
     private var gateway: PushGateway? = null
 


### PR DESCRIPTION
Allow users to configure additional labels for PushGateway metrics via the groupingKey config option. This enables adding labels like service, task, environment, etc.

Example config:
  pushGateway:
    groupingKey:
      service: "my-service"
      task: "my-task"