### PR TITLE
Add Folia scheduler support to Bukkit platform

### DIFF
--- a/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/FoliaGlobalDispatcher.kt
+++ b/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/FoliaGlobalDispatcher.kt
@@ -1,0 +1,70 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.bukkit
+
+import kotlinx.coroutines.*
+import org.bukkit.plugin.Plugin
+import org.bukkit.plugin.java.JavaPlugin
+import java.util.function.Consumer
+import kotlin.coroutines.CoroutineContext
+import kotlin.math.ceil
+import kotlin.math.max
+
+/**
+ * Dispatches platform-owned collection work through Folia's global region scheduler.
+ *
+ * Reflection preserves UnifiedMetrics' Bukkit 1.8+ linkage while using the public Folia scheduler API when present.
+ */
+@OptIn(InternalCoroutinesApi::class)
+class FoliaGlobalDispatcher(private val plugin: JavaPlugin) : CoroutineDispatcher(), Delay {
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        if (!context.isActive) {
+            return
+        }
+
+        val scheduler = globalScheduler()
+        scheduler.javaClass
+            .getMethod("execute", Plugin::class.java, Runnable::class.java)
+            .invoke(scheduler, plugin, block)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        val scheduler = globalScheduler()
+        val ticks = max(1L, ceil(timeMillis / MILLIS_PER_TICK).toLong())
+        val task = scheduler.javaClass
+            .getMethod("runDelayed", Plugin::class.java, Consumer::class.java, Long::class.javaPrimitiveType)
+            .invoke(
+                scheduler,
+                plugin,
+                Consumer<Any> { continuation.apply { resumeUndispatched(Unit) } },
+                ticks
+            )
+
+        continuation.invokeOnCancellation {
+            task.javaClass.getMethod("cancel").invoke(task)
+        }
+    }
+
+    private fun globalScheduler(): Any =
+        plugin.server.javaClass.getMethod("getGlobalRegionScheduler").invoke(plugin.server)
+
+    private companion object {
+        const val MILLIS_PER_TICK = 50.0
+    }
+}

--- a/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/FoliaGlobalDispatcher.kt
+++ b/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/FoliaGlobalDispatcher.kt
@@ -57,7 +57,9 @@ class FoliaGlobalDispatcher(private val plugin: JavaPlugin) : CoroutineDispatche
             )
 
         continuation.invokeOnCancellation {
-            task.javaClass.getMethod("cancel").invoke(task)
+            Class.forName("io.papermc.paper.threadedregions.scheduler.ScheduledTask")
+                .getMethod("cancel")
+                .invoke(task)
         }
     }
 

--- a/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/UnifiedMetricsBukkitPlugin.kt
+++ b/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/UnifiedMetricsBukkitPlugin.kt
@@ -23,6 +23,7 @@ import dev.cubxity.plugins.metrics.bukkit.metric.events.EventsCollection
 import dev.cubxity.plugins.metrics.bukkit.metric.server.ServerCollection
 import dev.cubxity.plugins.metrics.bukkit.metric.tick.TickCollection
 import dev.cubxity.plugins.metrics.bukkit.metric.world.WorldCollection
+import dev.cubxity.plugins.metrics.bukkit.util.BukkitPlatform
 import dev.cubxity.plugins.metrics.core.plugin.CoreUnifiedMetricsPlugin
 import org.bukkit.plugin.ServicePriority
 import java.util.concurrent.Executors
@@ -48,7 +49,9 @@ class UnifiedMetricsBukkitPlugin(
             with(config.metrics.collectors) {
                 if (server) registerCollection(ServerCollection(bootstrap))
                 if (world) registerCollection(WorldCollection(bootstrap))
-                if (tick) registerCollection(TickCollection(bootstrap))
+                if (tick && BukkitPlatform.current != BukkitPlatform.FOLIA) {
+                    registerCollection(TickCollection(bootstrap))
+                }
                 if (events) registerCollection(EventsCollection(bootstrap))
             }
         }

--- a/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/bootstrap/UnifiedMetricsBukkitBootstrap.kt
+++ b/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/bootstrap/UnifiedMetricsBukkitBootstrap.kt
@@ -19,7 +19,9 @@ package dev.cubxity.plugins.metrics.bukkit.bootstrap
 
 import dev.cubxity.plugins.metrics.api.platform.PlatformType
 import dev.cubxity.plugins.metrics.bukkit.BukkitDispatcher
+import dev.cubxity.plugins.metrics.bukkit.FoliaGlobalDispatcher
 import dev.cubxity.plugins.metrics.bukkit.UnifiedMetricsBukkitPlugin
+import dev.cubxity.plugins.metrics.bukkit.util.BukkitPlatform
 import dev.cubxity.plugins.metrics.common.UnifiedMetricsBootstrap
 import dev.cubxity.plugins.metrics.common.plugin.logger.JavaLogger
 import kotlinx.coroutines.CoroutineDispatcher
@@ -47,9 +49,13 @@ class UnifiedMetricsBukkitBootstrap : JavaPlugin(), UnifiedMetricsBootstrap {
 
     override val logger = JavaLogger(getLogger())
 
-    override val dispatcher: CoroutineDispatcher = BukkitDispatcher(this)
+    override val dispatcher: CoroutineDispatcher = when (BukkitPlatform.current) {
+        BukkitPlatform.FOLIA -> FoliaGlobalDispatcher(this)
+        else -> BukkitDispatcher(this)
+    }
 
     override fun onEnable() {
+        logger.info("Running on Bukkit platform ${BukkitPlatform.current}")
         plugin.enable()
     }
 

--- a/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/metric/events/EventsCollection.kt
+++ b/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/metric/events/EventsCollection.kt
@@ -22,7 +22,6 @@ package dev.cubxity.plugins.metrics.bukkit.metric.events
 import dev.cubxity.plugins.metrics.api.metric.collector.Collector
 import dev.cubxity.plugins.metrics.api.metric.collector.CollectorCollection
 import dev.cubxity.plugins.metrics.api.metric.collector.Counter
-import dev.cubxity.plugins.metrics.api.metric.store.VolatileDoubleStore
 import dev.cubxity.plugins.metrics.bukkit.bootstrap.UnifiedMetricsBukkitBootstrap
 import dev.cubxity.plugins.metrics.common.metric.Metrics
 import org.bukkit.event.EventHandler
@@ -37,8 +36,8 @@ import org.bukkit.event.server.ServerListPingEvent
 @Suppress("UNUSED_PARAMETER")
 class EventsCollection(private val bootstrap: UnifiedMetricsBukkitBootstrap) : CollectorCollection, Listener {
     private val loginCounter = Counter(Metrics.Events.Login)
-    private val joinCounter = Counter(Metrics.Events.Join, valueStoreFactory = VolatileDoubleStore)
-    private val quitCounter = Counter(Metrics.Events.Quit, valueStoreFactory = VolatileDoubleStore)
+    private val joinCounter = Counter(Metrics.Events.Join)
+    private val quitCounter = Counter(Metrics.Events.Quit)
     private val chatCounter = Counter(Metrics.Events.Chat)
     private val pingCounter = Counter(Metrics.Events.Ping) // TODO: is this async?
 

--- a/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/util/BukkitPlatform.kt
+++ b/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/util/BukkitPlatform.kt
@@ -1,0 +1,34 @@
+/*
+ *     This file is part of UnifiedMetrics.
+ *
+ *     UnifiedMetrics is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     UnifiedMetrics is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with UnifiedMetrics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.cubxity.plugins.metrics.bukkit.util
+
+enum class BukkitPlatform {
+    BUKKIT,
+    PAPER,
+    FOLIA;
+
+    companion object {
+        val current: BukkitPlatform by lazy {
+            when {
+                classExists("io.papermc.paper.threadedregions.RegionizedServer") -> FOLIA
+                classExists("com.destroystokyo.paper.event.server.ServerTickStartEvent") -> PAPER
+                else -> BUKKIT
+            }
+        }
+    }
+}

--- a/platforms/bukkit/src/main/resources/plugin.yml
+++ b/platforms/bukkit/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: UnifiedMetrics
 main: dev.cubxity.plugins.metrics.bukkit.bootstrap.UnifiedMetricsBukkitBootstrap
 description: "Fully-featured metrics plugin for Minecraft servers"
 api-version: 1.16
+folia-supported: true
 author: Cubxity
 version: ${version}
 load: STARTUP


### PR DESCRIPTION
Adds explicit Folia support while preserving the existing Bukkit 1.8+ linkage through reflection.

Changes:
- detect Folia and dispatch collection work through the global region scheduler
- use the public ScheduledTask interface for delayed-task cancellation
- mark the Bukkit plugin as folia-supported
- skip the single-global-tick collector on Folia, where that metric is not meaningful
- keep server, world, event, and system collectors enabled
- make join/quit counters atomic

Verified with:
`./gradlew --configure-on-demand :unifiedmetrics-platform-bukkit:assemble -x signArchives`